### PR TITLE
Improve clickable area of note elements

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -31,6 +31,10 @@ body {
 	-webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
 }
 
+g[id^="note-"] {
+    pointer-events: bounding-box;
+}
+
 g[id^="clef-"]:hover,
 g[id^="ksig-"]:hover,
 g[id^="msig-"]:hover,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -31,7 +31,9 @@ body {
 	-webkit-box-shadow: 0 0 1px rgba(255,255,255,.5);
 }
 
-g[id^="note-"] {
+g[id^="note-"],
+g[id^="rest-"],
+g[id^="chord-"] {
     pointer-events: bounding-box;
 }
 


### PR DESCRIPTION
This PR improves the clickability of notes by adding the css property `pointer-events: bounding-box;`. Note that this will only work in chrome.

If the clickable area is too big for you it could be improved to at least improve the clickability of non filled noted such as half notes and whole notes:

```css
g[id^="note-"] .notehead,
g[id^="rest-"] .notehead,
g[id^="chord-"] .notehead {
    pointer-events: bounding-box;
}
```